### PR TITLE
Add _.findWhere()

### DIFF
--- a/Underscore.cfc
+++ b/Underscore.cfc
@@ -211,6 +211,21 @@ component {
   	public any function detect(obj, iterator, this) {
  		return _.find(argumentCollection = arguments);
  	}
+ 	
+ 	/**
+ 	* 	@header _.findWhere(collection, properties) : any
+ 	* 	@hint Looks through the collection and returns the first value that matches all of the key-value pairs listed in properties.
+ 	* 	@example _.findWhere(publicServicePulitzers, {newsroom: "The New York Times"});<br />=> {year: 1918, newsroom: "The New York Times",<br />    reason: "For its public service in publishing in full so many official reports,<br />    documents and speeches by European statesmen relating to the progress and<br />    conduct of the war."}
+ 	*/
+	public any function findWhere(obj = this.obj, required attrs) {
+		if (_.isEmpty(attrs)) return [];
+		return _.find(obj, function(value) {
+			for (var key in attrs) {
+				if (attrs[key] != value[key]) return false;
+				return true;	
+			}
+		});	
+	} 
 
  	/**
 	* 	@header _.filter(collection, iterator, [context]) : array

--- a/mxunit_tests/collectionsTest.cfc
+++ b/mxunit_tests/collectionsTest.cfc
@@ -253,6 +253,16 @@ component extends="mxunit.framework.TestCase" {
 	    assertEquals(2, _.size(result));
 	    assertEquals(1, result[1].a);
 	}
+	
+	public void function testFindWhere() {
+		var list = [{a: 1, b: 2}, {a: 2, b: 2}, {a: 1, b: 3}, {a: 1, b: 4}];
+	    var result = _.findWhere(list, {a: 1});
+	    assertEquals(2, result.b);
+	    result = _.findWhere(list, {b: 3});
+	    assertEquals(1, result.a);
+	    result = _.findWhere(list, {a: 1, b: 3});
+	    assertEquals(1, result.a);
+	}
 
 	public void function testMax() {
 	    assertEquals(3, _.max([1, 2, 3]), 'can perform a regular Math.max');


### PR DESCRIPTION
Added the _.findWhere(collection, properties) method, which looks through the collection and returns the first value that matches all of the key-value pairs listed in properties.
