### PR TITLE
Update Underscore.cfc

### DIFF
--- a/Underscore.cfc
+++ b/Underscore.cfc
@@ -481,7 +481,7 @@ component {
 		if (_.isEmpty(attrs)) return [];
 		return _.filter(obj, function(value) {
 			for (var key in attrs) {
-				if (attrs[key] != value[key]) return false;
+				if (!structKeyExists(value, key) || attrs[key] != value[key]) return false;
 			}
 			return true;
 		});


### PR DESCRIPTION
Fixes the filter function in 'where' to return false for any objects in collection that do not have the specified property instead of throwing an exception.
