### PR TITLE
Fix ambiguous scoping issue

### DIFF
--- a/Underscore.cfc
+++ b/Underscore.cfc
@@ -870,15 +870,15 @@ component {
 	*/
 	public any function slice(array = [], numeric from = 2, numeric to) {
 		var len = arrayLen(array);
-		to = (!structKeyExists(arguments, 'to')) ? len + 1 :
+		var calculatedTo = (!structKeyExists(arguments, 'to')) ? len + 1 :
 			 (to > (len + 1)) ? len + 1 :
 			 (to < 0) ? to + len + 1 :
 			 to + 1;
-		from = (from > 0) ? from :
+		var calculatedFrom = (from > 0) ? from :
 			   (from < 0) ? from + len + 1 :
 			   0;
 		if (from == 0){ throw("CF Arrays start with index 1", "Underscore"); }
-		var sliceLen = arguments.to - arguments.from;
+		var sliceLen = calculatedTo - calculatedFrom;
 		if (sliceLen <= 0){ return []; }
 		return arraySlice(array, from, sliceLen);
 	}

--- a/Underscore.cfc
+++ b/Underscore.cfc
@@ -880,7 +880,7 @@ component {
 		if (from == 0){ throw("CF Arrays start with index 1", "Underscore"); }
 		var sliceLen = calculatedTo - calculatedFrom;
 		if (sliceLen <= 0){ return []; }
-		return arraySlice(array, from, sliceLen);
+		return arraySlice(array, calculatedFrom, sliceLen);
 	}
 
 	/**


### PR DESCRIPTION
In cases where the optional `to` argument is not provided to `slice()`, the scoping of `arguments.to` on line 881 fails because `arguments.to` is scoped too specifically. The unscoped `to` assignment on line 873 is thus not an overwriting of `arguments.to`, but instead the creation of a non-locally-scoped variable (in effect, `variables.to`, depending on the cfml engine being used and settings in effect). 

This change removes the ambiguity by locally var-scoping `calculatedTo` and `calculatedFrom`. The latter is technically unnecessary because the `from` argument includes a default value and therefore always exists, but I added it for symmetry and clarity.
