### PR TITLE
Fix findWhere search when using search struct with multiple keys

### DIFF
--- a/Underscore.cfc
+++ b/Underscore.cfc
@@ -222,8 +222,8 @@ component {
 		return _.find(obj, function(value) {
 			for (var key in attrs) {
 				if (attrs[key] != value[key]) return false;
-				return true;
 			}
+			return true;
 		});
 	}
 

--- a/mxunit_tests/collectionsTest.cfc
+++ b/mxunit_tests/collectionsTest.cfc
@@ -264,7 +264,7 @@ component extends="mxunit.framework.TestCase" {
 	    result = _.findWhere(list, {b: 3});
 	    assertEquals(1, result.a);
 	    result = _.findWhere(list, {a: 1, b: 3});
-	    assertEquals(1, result.a);
+	    assertEquals(3, result.b);
 	}
 
 	public void function testMax() {


### PR DESCRIPTION
I noticed findWhere wasn't living up to it's documented behavior to "Looks through the collection and returns the first value that matches all of the key-value pairs listed in properties." and was instead returning the first struct that matched any of the key value pairs listed in properties. This should fix that.